### PR TITLE
Removing building armeabi-v7a-neon and arm64

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SUPPORTED_ARCHITECTURES=(armeabi-v7a armeabi-v7a-neon x86 arm64)
+SUPPORTED_ARCHITECTURES=(armeabi-v7a x86)
 ANDROID_NDK_ROOT_PATH=${ANDROID_NDK}
 if [[ -z "$ANDROID_NDK_ROOT_PATH" ]]; then
   echo "You need to set ANDROID_NDK environment variable, please check instructions"


### PR DESCRIPTION
These targets are not needed for now, removing them
to quicken the build.