### PR TITLE
Remove filters and network

### DIFF
--- a/ffmpeg_build.sh
+++ b/ffmpeg_build.sh
@@ -43,6 +43,12 @@ make clean
 --disable-debug \
 --disable-ffserver \
 --disable-network \
+--disable-filters \
+--enable-filter=fps \
+--enable-filter=split \
+--enable-filter=palettegen \
+--enable-filter=fifo \
+--enable-filter=paletteuse \
 --enable-version3 \
 --enable-hardcoded-tables \
 --disable-ffplay \

--- a/ffmpeg_build.sh
+++ b/ffmpeg_build.sh
@@ -42,6 +42,7 @@ make clean
 --enable-pthreads \
 --disable-debug \
 --disable-ffserver \
+--disable-network \
 --enable-version3 \
 --enable-hardcoded-tables \
 --disable-ffplay \


### PR DESCRIPTION
Remove network features from FFmpeg as well as all filters which are not used by the target application to convert to gif. The goal is to reduce the size of the FFmpeg and FFprobe binaries.